### PR TITLE
[DOCUMENTATION] adding setup guide to repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Then from  **~ADAPT/** directory, run this script:
 ```
 ##
 
-If the docker-compose version is visible, the tools built successfully.
+If the docker-compose version is visible after running the script, the tools built successfully.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,5 @@ Then from  **~ADAPT/** directory, run this script:
 ./Setup-Environment/setup-ubuntu-script.sh
 ```
 ##
+
+If the docker-compose version is visible, the tools built successfully.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # ADAPT
 Active Detection of Advanced Persistent Threats
+
+## VM Setup / Configuration
+### Ubuntu:
+
+First make the script executable.
+```
+chmod +x /Setup-Environment/setup-ubuntu-script.sh
+```
+Then from  **~ADAPT/** directory, run this script:
+```
+./Setup-Environment/setup-ubuntu-script.sh
+```
+##


### PR DESCRIPTION
 - Do we want to have all instructions on the main readme or a readme for separate sections?
  - I think one readme will probably work because I don't think we will have a lot of documentation outside of setup and notes about "getting started"
- If we have one central readme, this branch updates README.md with setup instructions
